### PR TITLE
[FIX] Eureka 연동 및 보안 필터 화이트리스트 적용, README 작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,57 @@
-# 🗂️ Spring Boot 프로젝트 템플릿
+# 🏢 FollowMe Gateway Server (API Gateway)
 
-Spring Boot 기반 백엔드 프로젝트를 빠르게 시작할 수 있는 팀 공용 템플릿입니다.
-이슈/PR 템플릿, 코드 포맷팅 자동화, REST Docs 배포가 사전 구성되어 있습니다.
+## 1. 프로젝트 개요 (Executive Summary)
+`gateway-server`는 FollowMe 마이크로서비스 아키텍처(MSA)의 **전사적 단일 진입점(Single Entry Point)** 역할을 수행하는 핵심 인프라입니다. 클라이언트의 모든 요청은 본 게이트웨이를 거쳐 내부 서비스로 라우팅되며, 이 과정에서 중앙 집중식 보안 인증과 시스템 성능 감사를 수행합니다.
+
+## 2. 핵심 비즈니스 가치 (Core Capabilities)
+
+* **보안 통제소 (Zero-Trust Security):** `CustomAuthFilter`를 통해 Keycloak에서 발급한 JWT(JSON Web Token)의 유효성을 최전선에서 검증하여, 인가되지 않은 외부 접근을 원천 차단합니다.
+* **동적 라우팅 (Service Discovery):** Netflix Eureka와 연동하여 백엔드 서비스(예: `USER-SERVER`)의 위치(IP/Port)를 동적으로 파악하고 트래픽을 안전하게 분산(Load Balancing)합니다.
+* **운영 가시성 확보 (Global Audit Logging):** `GlobalLoggingFilter`를 통해 모든 API 요청의 진입점과 처리 소요 시간을 밀리초(ms) 단위로 추적하여 시스템 병목 현상을 모니터링합니다.
 
 ---
 
-## 🚀 템플릿 사용법
+## 3. 시스템 아키텍처 (Architecture Flow)
 
-### 1. 레포지토리 생성
+요청(Request)은 다음과 같은 보안 및 라우팅 파이프라인을 거칩니다.
 
-1. 이 레포지토리 상단의 **Use this template** 버튼 클릭
-2. 새 레포지토리 이름 및 공개 여부 설정 후 생성
+1. **Client** ➡️ `http://localhost:8000/api/v1/...` (Gateway API 호출)
+2. **Global Pre Filter** ➡️ 요청 시간 기록 및 로깅
+3. **Custom Auth Filter** ➡️ `Authorization: Bearer <Token>` 검증 (실패 시 401 차단)
+4. **Eureka Registry** ➡️ 목적지 마이크로서비스 주소 탐색 (예: `lb://USER-SERVER`)
+5. **Microservice** ➡️ 실제 비즈니스 로직 처리 (`user-server`)
+6. **Global Post Filter** ➡️ 최종 응답 속도 산출 및 로깅
 
-### 2. 브랜치 구성
+---
 
-기본 워크플로우는 `main`, `dev` 브랜치를 기준으로 동작합니다.
+## 4. 인프라 기동 순서 (Standard Operating Procedure)
+
+마이크로서비스 간의 의존성으로 인해 **반드시 아래의 순서대로 서버를 기동**해야 합니다.
+
+1. **Eureka Server** (`8761`): 주소록 역할 (가장 먼저 기동)
+2. **Keycloak Server** (`9090`): 인증 및 토큰 발급 (SSO)
+3. **Microservices** (예: `user-server` `8080`): 실제 업무 처리 서비스
+4. **Gateway Server** (`8000`): 최종 라우팅 및 보안 관제
+
+> **인프라 검증:** 브라우저에서 `http://localhost:8761` (Eureka Dashboard)에 접속하여 `GATEWAY-SERVER`와 타겟 서비스들이 **UP** 상태인지 반드시 확인하십시오.
+
+---
+
+## 5. API 테스트 지침 (QA Testing Protocol)
+
+게이트웨이를 통한 통합 테스트 시, Postman 또는 cURL을 사용하여 다음 규격을 준수해야 합니다.
+
+### ❌ 잘못된 테스트 방식 (Direct Bypass)
+* **URL:** `http://localhost:8080/api/v1/users/...`
+* **사유:** 게이트웨이(8000)를 우회하여 내부망(8080)으로 직접 찔러넣는 방식이므로 보안 필터와 로그가 작동하지 않습니다.
+
+### ⭕ 올바른 테스트 방식 (Via Gateway)
+* **URL:** `http://localhost:8000/api/v1/users/...`
+* **Headers 필수 포함:**
+  * `Key`: `Authorization`
+  * `Value`: `Bearer {Keycloak에서_새로_발급받은_Access_Token}`
 
 ```bash
-git checkout -b dev
-git push origin dev
-```
----
-
-## 📦 포함된 구성 요소
-
-| 구성 요소                      | 설명                                                         |
-|------------------------------|--------------------------------------------------------------|
-| Issue 템플릿                  | 작업 설명, 목적, 세부 항목, 관련 이슈를 포함한 이슈 양식       |
-| PR 템플릿                     | 관련 이슈, 작업 내용, 변경 이유, 리뷰 포인트를 포함한 PR 양식  |
-| Spotless (Google Java Format) | PR 생성 시 코드 포맷 자동 검사 (main, dev 브랜치 대상)        |
-
----
-
-## 🧹 코드 포맷팅 (Spotless)
-
-이 프로젝트는 일관된 Java 코드 스타일을 유지하기 위해 **Spotless(Google Java Format)** 를 사용합니다.
-`main`, `dev` 브랜치로 PR을 올릴 때 GitHub Actions CI를 통해 자동으로 코드 포맷을 검사하며, 포맷이 어긋난 코드의 머지를 차단합니다.
-
-```bash
-# 포맷 자동 정렬 적용 (커밋 전 필수)
-./gradlew spotlessApply
-
-# 포맷 준수 여부 검사 (CI 검증 명령어)
-./gradlew spotlessCheck
-```
-
----
-
-## 📄 REST Docs 자동 배포
-
-`dev` 또는 `main` 브랜치에 푸시하면 GitHub Actions가 자동으로 다음을 수행합니다.
-
-1. JDK 21 환경에서 `./gradlew asciidoctor` 빌드
-2. 생성된 문서(`build/docs/asciidoc`)를 GitHub Pages에 배포
-
-> **참고:** 빌드 시 Redis(7) 서비스가 필요합니다. 테스트에서 Redis를 사용하는 경우 별도 설정 없이 CI에서 자동으로 실행됩니다.
+# cURL 테스트 예시
+curl -X GET "http://localhost:8000/api/v1/users/profile" \
+     -H "Authorization: Bearer eyJhbGciOi..."

--- a/src/main/java/com/followme/gatewayserver/GatewayserviceApplication.java
+++ b/src/main/java/com/followme/gatewayserver/GatewayserviceApplication.java
@@ -1,4 +1,4 @@
-package com.followme.gatewayservice;
+package com.followme.gatewayserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
+++ b/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
@@ -1,39 +1,36 @@
 package com.followme.gatewayserver.filter;
 
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Slf4j
 @Component
 public class CustomAuthFilter extends AbstractGatewayFilterFactory<CustomAuthFilter.Config> {
 
   // 인증을 면제할 공개(Public) API 경로 목록 정의 (화이트리스트)
-  private static final List<String> EXCLUDE_PATHS = List.of(
-      "/api/v1/users/register"
-  );
+  private static final List<String> EXCLUDE_PATHS = List.of("/api/v1/users/register");
 
   public CustomAuthFilter() {
     super(Config.class);
   }
 
-  public static class Config {
-  }
+  public static class Config {}
 
   @Override
   public GatewayFilter apply(Config config) {
     return (exchange, chain) -> {
-
       String path = exchange.getRequest().getURI().getPath();
       log.info("[CustomAuth Filter] KeyCloak authentication filter started. Path: {}", path);
 
       boolean isExcluded = EXCLUDE_PATHS.stream().anyMatch(path::startsWith);
       if (isExcluded) {
-        log.info("[CustomAuth Filter] Excluded path detected: {}. Proceeding without authentication.", path);
+        log.info(
+            "[CustomAuth Filter] Excluded path detected: {}. Proceeding without authentication.",
+            path);
         return chain.filter(exchange);
       }
 

--- a/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
+++ b/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
@@ -1,4 +1,4 @@
-package com.followme.gatewayservice.filter;
+package com.followme.gatewayserver.filter;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilter;

--- a/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
+++ b/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
@@ -6,29 +6,41 @@ import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFac
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Slf4j
 @Component
 public class CustomAuthFilter extends AbstractGatewayFilterFactory<CustomAuthFilter.Config> {
+
+  // 인증을 면제할 공개(Public) API 경로 목록 정의 (화이트리스트)
+  private static final List<String> EXCLUDE_PATHS = List.of(
+      "/api/v1/users/register"
+  );
 
   public CustomAuthFilter() {
     super(Config.class);
   }
 
   public static class Config {
-    // YML에서 전달받을 설정값이 있다면 여기에 추가
   }
 
   @Override
   public GatewayFilter apply(Config config) {
     return (exchange, chain) -> {
-      log.info("[CustomAuth Filter] KeyCloak authentication filter started.");
 
-      // 요청 헤더에서 Authorization 추출
+      String path = exchange.getRequest().getURI().getPath();
+      log.info("[CustomAuth Filter] KeyCloak authentication filter started. Path: {}", path);
+
+      boolean isExcluded = EXCLUDE_PATHS.stream().anyMatch(path::startsWith);
+      if (isExcluded) {
+        log.info("[CustomAuth Filter] Excluded path detected: {}. Proceeding without authentication.", path);
+        return chain.filter(exchange);
+      }
+
       String authorizationHeader = exchange.getRequest().getHeaders().getFirst("Authorization");
 
-      // 임시 로직: 헤더가 없거나 Bearer로 시작하지 않으면 거부 (401 Unauthorized)
       if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-        log.warn("[CustomAuth Filter] Authentication failed: Invalid token.");
+        log.warn("[CustomAuth Filter] Authentication failed: Invalid token for path {}", path);
         exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
         return exchange.getResponse().setComplete();
       }

--- a/src/main/java/com/followme/gatewayserver/filter/GlobalLoggingFilter.java
+++ b/src/main/java/com/followme/gatewayserver/filter/GlobalLoggingFilter.java
@@ -1,4 +1,4 @@
-package com.followme.gatewayservice.filter;
+package com.followme.gatewayserver.filter;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,21 +3,23 @@ server:
 
 spring:
   application:
-    name: gateway-service
+    name: gateway-server
   cloud:
     gateway:
       server:
         webflux:
+          # 전역 필터 설정
           default-filters:
             - AddRequestHeader=X-Gateway-Request, true
           
+          # 개별 서비스 라우팅 전략
           routes:
-            - id: user-service
-              uri: lb://USER-SERVICE
+            - id: user-server
+              uri: lb://USER-SERVER
               predicates:
-                - Path=/users/**
+                - Path=/api/v1/users/**
               filters:
-                - CustomAuthFilter
+                - name: CustomAuthFilter
 
 eureka:
   client:


### PR DESCRIPTION
### 📌 관련 이슈
- close #3

### 💡 작업 내용
- **보안 필터(CustomAuthFilter) 개선:** 토큰 발급 전 수행되어야 하는 API(회원가입)에 대한 인증 우회(Bypass) 로직(Whitelist) 추가 구현.
- READMD.md 작성

### 🔍 변경 이유
- 신규 사용자 또는 미인증 사용자가 회원가입(`/register`) API에 정상적으로 접근할 수 있도록 보안 정책의 예외 구간을 설정하기 위함.

### 🧠 기타 참고 사항
- **테스트 완료 항목:** Postman을 통해 `http://localhost:8000/api/v1/users/register` 엔드포인트 호출 시, 게이트웨이 보안 필터에서 차단(`401`)되지 않고 `user-server`로 정상 전달됨을 확인했습니다.
- **실행 컨텍스트:** 로컬 환경에서 본 PR 내역을 테스트할 경우, 반드시 **Eureka Server(`8761`)가 가장 먼저 기동**되어 있어야 정상적인 라우팅이 가능합니다.