### PR TITLE
[FEAT] WebClient 기반 API Gateway 실시간 인증 로직 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,82 @@
-# 🏢 FollowMe Gateway Server (API Gateway)
+# 🚀 API Gateway Server
 
-## 1. 프로젝트 개요 (Executive Summary)
-`gateway-server`는 FollowMe 마이크로서비스 아키텍처(MSA)의 **전사적 단일 진입점(Single Entry Point)** 역할을 수행하는 핵심 인프라입니다. 클라이언트의 모든 요청은 본 게이트웨이를 거쳐 내부 서비스로 라우팅되며, 이 과정에서 중앙 집중식 보안 인증과 시스템 성능 감사를 수행합니다.
+B2B 물류 배송 시스템(SpartaHub)의 단일 진입점(Single Point of Contact)을 담당하는 API Gateway입니다. 외부 트래픽을 각 마이크로서비스로 라우팅하고, 중앙 집중식 인증 및 인가를 수행합니다.
 
-## 2. 핵심 비즈니스 가치 (Core Capabilities)
+## ✨ 핵심 기능
 
-* **보안 통제소 (Zero-Trust Security):** `CustomAuthFilter`를 통해 Keycloak에서 발급한 JWT(JSON Web Token)의 유효성을 최전선에서 검증하여, 인가되지 않은 외부 접근을 원천 차단합니다.
-* **동적 라우팅 (Service Discovery):** Netflix Eureka와 연동하여 백엔드 서비스(예: `USER-SERVER`)의 위치(IP/Port)를 동적으로 파악하고 트래픽을 안전하게 분산(Load Balancing)합니다.
-* **운영 가시성 확보 (Global Audit Logging):** `GlobalLoggingFilter`를 통해 모든 API 요청의 진입점과 처리 소요 시간을 밀리초(ms) 단위로 추적하여 시스템 병목 현상을 모니터링합니다.
-
----
-
-## 3. 시스템 아키텍처 (Architecture Flow)
-
-요청(Request)은 다음과 같은 보안 및 라우팅 파이프라인을 거칩니다.
-
-1. **Client** ➡️ `http://localhost:8000/api/v1/...` (Gateway API 호출)
-2. **Global Pre Filter** ➡️ 요청 시간 기록 및 로깅
-3. **Custom Auth Filter** ➡️ `Authorization: Bearer <Token>` 검증 (실패 시 401 차단)
-4. **Eureka Registry** ➡️ 목적지 마이크로서비스 주소 탐색 (예: `lb://USER-SERVER`)
-5. **Microservice** ➡️ 실제 비즈니스 로직 처리 (`user-server`)
-6. **Global Post Filter** ➡️ 최종 응답 속도 산출 및 로깅
+- **동적 라우팅:** Eureka Service Discovery를 통해 대상 서버로 트래픽을 로드밸런싱합니다.
+- **실시간 권한 검증 (Stateful Auth):** 외부 요청의 위조된 헤더를 초기화하고, JWT 토큰을 바탕으로 User Server와 내부 통신(`WebClient`)하여 유저의 실시간 상태(`APPROVED`)를 검증합니다.
+- **글로벌 CORS 처리:** 프론트엔드 연동을 위한 전역 CORS 설정을 관리하여 하위 서비스의 부담을 줄입니다.
 
 ---
 
-## 4. 인프라 기동 순서 (Standard Operating Procedure)
+## 🗺️ 라우팅 규격 (Architecture)
 
-마이크로서비스 간의 의존성으로 인해 **반드시 아래의 순서대로 서버를 기동**해야 합니다.
+외부에서 들어오는 모든 요청은 아래의 경로 규칙에 따라 각 마이크로서비스로 전달됩니다.
 
-1. **Eureka Server** (`8761`): 주소록 역할 (가장 먼저 기동)
-2. **Keycloak Server** (`9090`): 인증 및 토큰 발급 (SSO)
-3. **Microservices** (예: `user-server` `8080`): 실제 업무 처리 서비스
-4. **Gateway Server** (`8000`): 최종 라우팅 및 보안 관제
+| 마이크로서비스 | 라우팅 경로 (Predicates) | 비고 |
+|---|---|---|
+| **User Server** | `/api/v1/users/**` | 회원가입(`/register`)은 인증 필터 패스 |
+| **Hub Server** | `/api/v1/hubs/**`, `/api/v1/hub-routes/**`, `/api/v1/stocks/**`, `/api/v1/stock-histories/**` | |
+| **Vendor Server** | `/api/v1/vendors/**`, `/api/v1/products/**` | |
+| **Order Server** | `/api/v1/orders/**` | |
+| **Delivery Server** | `/api/v1/deliveries/**`, `/api/v1/shipments/**` | |
+| **Message Server**| `/api/v1/slack-messages/**`, `/api/v1/notifications/**` | |
+| **AI Server** | `/api/v1/ai/**` | |
 
-> **인프라 검증:** 브라우저에서 `http://localhost:8761` (Eureka Dashboard)에 접속하여 `GATEWAY-SERVER`와 타겟 서비스들이 **UP** 상태인지 반드시 확인하십시오.
+> ⚠️ **주의:** `/internal/**` 로 시작하는 내부 통신용 API는 라우팅 규칙에서 제외되어 있으므로 외부(Postman, Frontend)에서 직접 호출할 수 없습니다.
 
 ---
 
-## 5. API 테스트 지침 (QA Testing Protocol)
+## 🔑 내부 인증 헤더 (X-Headers) 사용 가이드
 
-게이트웨이를 통한 통합 테스트 시, Postman 또는 cURL을 사용하여 다음 규격을 준수해야 합니다.
+**API Gateway를 통과한 모든 요청에는 유저의 최신 정보가 HTTP Header에 담겨서 전달됩니다.**
+따라서 뒷단(Downstream)의 마이크로서비스 개발자들은 복잡한 JWT 검증 로직을 구현할 필요 없이, Request Header에서 값을 꺼내 쓰기만 하면 됩니다.
 
-### ❌ 잘못된 테스트 방식 (Direct Bypass)
-* **URL:** `http://localhost:8080/api/v1/users/...`
-* **사유:** 게이트웨이(8000)를 우회하여 내부망(8080)으로 직접 찔러넣는 방식이므로 보안 필터와 로그가 작동하지 않습니다.
+### 📦 전달되는 헤더 목록
 
-### ⭕ 올바른 테스트 방식 (Via Gateway)
-* **URL:** `http://localhost:8000/api/v1/users/...`
-* **Headers 필수 포함:**
-  * `Key`: `Authorization`
-  * `Value`: `Bearer {Keycloak에서_새로_발급받은_Access_Token}`
+| 헤더 이름 (Key) | 설명 (Value) | 예시 |
+|---|---|---|
+| `X-User-Id` | 유저의 고유 식별자 (UUID) | `123e4567-e89b-12d3-a456-426614174000` |
+| `X-Role` | 유저의 권한 등급 | `MASTER`, `HUB_MANAGER`, `VENDOR` 등 |
+| `X-Username` | 로그인 아이디 | `test_user_01` |
+| `X-User-Name` | 유저의 실제 이름 (URL 인코딩됨) | `%ED%99%8D%EA%B8%B8%EB%8F%99` (홍길동) |
+| `X-User-Email` | 유저 이메일 | `user@example.com` |
 
-```bash
-# cURL 테스트 예시
-curl -X GET "http://localhost:8000/api/v1/users/profile" \
-     -H "Authorization: Bearer eyJhbGciOi..."
+### 💻 각 마이크로서비스에서 X-Header를 사용하는 방법 (Spring Boot 예시)
+
+해당 마이크로서비스의 Controller에서 `@RequestHeader` 어노테이션을 사용하여 필요한 정보를 바로 꺼내어 비즈니스 로직에 활용하세요.
+
+```java
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@RestController
+public class OrderController {
+
+    @PostMapping("/api/v1/orders")
+    public ResponseEntity<String> createOrder(
+            @RequestHeader("X-User-Id") String userId,
+            @RequestHeader("X-Role") String role,
+            @RequestHeader(value = "X-User-Name", required = false) String encodedName
+    ) {
+        // 1. 권한 체크 예시 (Service 계층으로 넘겨서 처리해도 무방)
+        if (!role.equals("MASTER") && !role.equals("HUB_MANAGER")) {
+            return ResponseEntity.status(403).body("주문 생성 권한이 없습니다.");
+        }
+
+        // 2. 인코딩된 이름 디코딩 예시 (필요한 경우)
+        String realName = "";
+        if (encodedName != null) {
+            realName = URLDecoder.decode(encodedName, StandardCharsets.UTF_8);
+        }
+
+        // 3. 추출한 userId를 바탕으로 주문 로직 실행
+        // orderService.createOrder(userId, requestDto);
+
+        return ResponseEntity.ok(realName + "님의 주문이 접수되었습니다. (ID: " + userId + ")");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -45,10 +45,17 @@ B2B 물류 배송 시스템(SpartaHub)의 단일 진입점(Single Point of Conta
 
 ### 💻 각 마이크로서비스에서 X-Header를 사용하는 방법 (Spring Boot 예시)
 
-해당 마이크로서비스의 Controller에서 `@RequestHeader` 어노테이션을 사용하여 필요한 정보를 바로 꺼내어 비즈니스 로직에 활용하세요.
+먼저, 공통으로 사용할 권한 Enum 클래스를 생성합니다.
 
 ```java
-import org.springframework.web.bind.annotation.GetMapping;
+public enum UserRole {
+    MASTER, HUB_MANAGER, HUB_DELIVERY, STORE_MANAGER, STORE_DELIVERY, VENDOR, USER
+}
+
+Controller에서는 @RequestHeader로 값을 받아 Enum으로 변환하여 안전하게 사용합니다.
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import java.net.URLDecoder;
@@ -60,21 +67,24 @@ public class OrderController {
     @PostMapping("/api/v1/orders")
     public ResponseEntity<String> createOrder(
             @RequestHeader("X-User-Id") String userId,
-            @RequestHeader("X-Role") String role,
+            @RequestHeader("X-Role") String roleString, // 👈 String으로 먼저 받습니다.
             @RequestHeader(value = "X-User-Name", required = false) String encodedName
     ) {
-        // 1. 권한 체크 예시 (Service 계층으로 넘겨서 처리해도 무방)
-        if (!role.equals("MASTER") && !role.equals("HUB_MANAGER")) {
+        // 1. String을 안전한 Enum 타입으로 변환
+        UserRole role = UserRole.valueOf(roleString);
+
+        // 2. Enum을 활용한 안전한 권한 체크 (Service 계층으로 넘겨서 처리하는 것을 권장)
+        if (role != UserRole.MASTER && role != UserRole.HUB_MANAGER) {
             return ResponseEntity.status(403).body("주문 생성 권한이 없습니다.");
         }
 
-        // 2. 인코딩된 이름 디코딩 예시 (필요한 경우)
+        // 3. 인코딩된 이름 디코딩 예시 (필요한 경우)
         String realName = "";
         if (encodedName != null) {
             realName = URLDecoder.decode(encodedName, StandardCharsets.UTF_8);
         }
 
-        // 3. 추출한 userId를 바탕으로 주문 로직 실행
+        // 4. 추출한 userId를 바탕으로 주문 로직 실행
         // orderService.createOrder(userId, requestDto);
 
         return ResponseEntity.ok(realName + "님의 주문이 접수되었습니다. (ID: " + userId + ")");

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ B2B 물류 배송 시스템(SpartaHub)의 단일 진입점(Single Point of Conta
 | 헤더 이름 (Key) | 설명 (Value) | 예시 |
 |---|---|---|
 | `X-User-Id` | 유저의 고유 식별자 (UUID) | `123e4567-e89b-12d3-a456-426614174000` |
-| `X-Role` | 유저의 권한 등급 | `MASTER`, `HUB_MANAGER`, `VENDOR` 등 |
+| `X-Role` | 유저의 권한 등급 | `MASTER`, `HUB`, `VENDOR` 등 |
 | `X-Username` | 로그인 아이디 | `test_user_01` |
 | `X-User-Name` | 유저의 실제 이름 (URL 인코딩됨) | `%ED%99%8D%EA%B8%B8%EB%8F%99` (홍길동) |
 | `X-User-Email` | 유저 이메일 | `user@example.com` |
@@ -49,7 +49,7 @@ B2B 물류 배송 시스템(SpartaHub)의 단일 진입점(Single Point of Conta
 
 ```java
 public enum UserRole {
-    MASTER, HUB_MANAGER, HUB_DELIVERY, STORE_MANAGER, STORE_DELIVERY, VENDOR, USER
+    MASTER, HUB, VENDOR, DELIVERY
 }
 
 Controller에서는 @RequestHeader로 값을 받아 Enum으로 변환하여 안전하게 사용합니다.
@@ -74,7 +74,7 @@ public class OrderController {
         UserRole role = UserRole.valueOf(roleString);
 
         // 2. Enum을 활용한 안전한 권한 체크 (Service 계층으로 넘겨서 처리하는 것을 권장)
-        if (role != UserRole.MASTER && role != UserRole.HUB_MANAGER) {
+        if (role != UserRole.MASTER && role != UserRole.HUB) {
             return ResponseEntity.status(403).body("주문 생성 권한이 없습니다.");
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     implementation 'io.swagger.core.v3:swagger-annotations:2.2.20'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+    // 3. JWT 인증을 위한 리소스 서버 스타터
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/followme/gatewayserver/config/GatewaySecurityConfig.java
+++ b/src/main/java/com/followme/gatewayserver/config/GatewaySecurityConfig.java
@@ -1,0 +1,30 @@
+package com.followme.gatewayserver.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class GatewaySecurityConfig {
+
+    @Bean
+    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        http
+            .csrf(csrf -> csrf.disable())
+            
+            // 1. 경로별 접근 통제
+            .authorizeExchange(exchanges -> exchanges
+                .pathMatchers("/api/v1/auth/**", "/api/v1/public/**", "/api/v1/users/register").permitAll()
+                .anyExchange().authenticated() // 나머지는 무조건 인증(토큰) 필요
+            )
+            
+            // 2. application.yml에 적어둔 Keycloak 주소로 JWT 서명 검증 수행
+            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/followme/gatewayserver/config/GatewaySecurityConfig.java
+++ b/src/main/java/com/followme/gatewayserver/config/GatewaySecurityConfig.java
@@ -11,20 +11,23 @@ import org.springframework.security.web.server.SecurityWebFilterChain;
 @EnableWebFluxSecurity
 public class GatewaySecurityConfig {
 
-    @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
-        http
-            .csrf(csrf -> csrf.disable())
-            
-            // 1. 경로별 접근 통제
-            .authorizeExchange(exchanges -> exchanges
-                .pathMatchers("/api/v1/auth/**", "/api/v1/public/**", "/api/v1/users/register").permitAll()
-                .anyExchange().authenticated() // 나머지는 무조건 인증(토큰) 필요
-            )
-            
-            // 2. application.yml에 적어둔 Keycloak 주소로 JWT 서명 검증 수행
-            .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+  @Bean
+  public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+    http.csrf(csrf -> csrf.disable())
 
-        return http.build();
-    }
+        // 1. 경로별 접근 통제
+        .authorizeExchange(
+            exchanges ->
+                exchanges
+                    .pathMatchers("/api/v1/auth/**", "/api/v1/public/**", "/api/v1/users/register")
+                    .permitAll()
+                    .anyExchange()
+                    .authenticated() // 나머지는 무조건 인증(토큰) 필요
+            )
+
+        // 2. application.yml에 적어둔 Keycloak 주소로 JWT 서명 검증 수행
+        .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+
+    return http.build();
+  }
 }

--- a/src/main/java/com/followme/gatewayserver/config/WebClientConfig.java
+++ b/src/main/java/com/followme/gatewayserver/config/WebClientConfig.java
@@ -1,0 +1,16 @@
+package com.followme.gatewayserver.config;
+
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    @LoadBalanced // Eureka 네임서버를 통해 IP를 동적으로 찾아주는 핵심 어노테이션
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}

--- a/src/main/java/com/followme/gatewayserver/config/WebClientConfig.java
+++ b/src/main/java/com/followme/gatewayserver/config/WebClientConfig.java
@@ -8,9 +8,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class WebClientConfig {
 
-    @Bean
-    @LoadBalanced // Eureka 네임서버를 통해 IP를 동적으로 찾아주는 핵심 어노테이션
-    public WebClient.Builder webClientBuilder() {
-        return WebClient.builder();
-    }
+  @Bean
+  @LoadBalanced // Eureka 네임서버를 통해 IP를 동적으로 찾아주는 핵심 어노테이션
+  public WebClient.Builder webClientBuilder() {
+    return WebClient.builder();
+  }
 }

--- a/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
+++ b/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
@@ -22,10 +22,7 @@ import reactor.core.publisher.Mono;
 @Component
 public class CustomAuthFilter extends AbstractGatewayFilterFactory<CustomAuthFilter.Config> {
 
-  private static final List<String> PUBLIC_PREFIXES = List.of(
-      "/api/v1/auth/",
-      "/api/v1/public/"
-  );
+  private static final List<String> PUBLIC_PREFIXES = List.of("/api/v1/auth/", "/api/v1/public/");
 
   private final ObjectMapper objectMapper;
   private final WebClient webClient;

--- a/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
+++ b/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
@@ -22,11 +22,8 @@ import reactor.core.publisher.Mono;
 @Component
 public class CustomAuthFilter extends AbstractGatewayFilterFactory<CustomAuthFilter.Config> {
 
-  private static final List<String> PUBLIC_PREFIXES = List.of(
-    "/api/v1/auth/", 
-    "/api/v1/public/",
-    "/api/v1/users/register"
-  );
+  private static final List<String> PUBLIC_PREFIXES =
+      List.of("/api/v1/auth/", "/api/v1/public/", "/api/v1/users/register");
 
   private final ObjectMapper objectMapper;
   private final WebClient webClient;

--- a/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
+++ b/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
@@ -22,7 +22,11 @@ import reactor.core.publisher.Mono;
 @Component
 public class CustomAuthFilter extends AbstractGatewayFilterFactory<CustomAuthFilter.Config> {
 
-  private static final List<String> PUBLIC_PREFIXES = List.of("/api/v1/auth/", "/api/v1/public/");
+  private static final List<String> PUBLIC_PREFIXES = List.of(
+    "/api/v1/auth/", 
+    "/api/v1/public/",
+    "/api/v1/users/register"
+  );
 
   private final ObjectMapper objectMapper;
   private final WebClient webClient;

--- a/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
+++ b/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
@@ -4,7 +4,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.followme.gatewayserver.response.User;
 import com.followme.gatewayserver.response.UserResponse;
-
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
@@ -14,127 +18,142 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.Base64;
-import java.util.List;
-
 @Slf4j
 @Component
 public class CustomAuthFilter extends AbstractGatewayFilterFactory<CustomAuthFilter.Config> {
 
-    private static final List<String> EXCLUDE_PATHS = List.of(
-      "/api/v1/users/register",
-      "/v1/users/register", 
-      "/register"
-    );
-    
-    private final ObjectMapper objectMapper;
-    private final WebClient webClient;
+  private static final List<String> EXCLUDE_PATHS =
+      List.of("/api/v1/users/register", "/v1/users/register", "/register");
 
-    public CustomAuthFilter(ObjectMapper objectMapper, WebClient.Builder webClientBuilder) {
-        super(Config.class);
-        this.objectMapper = objectMapper;
-        // Eureka에 등록된 User Server의 이름(대소문자 주의)으로 베이스 URL 세팅
-        this.webClient = webClientBuilder.baseUrl("http://user-server").build(); 
-    }
+  private final ObjectMapper objectMapper;
+  private final WebClient webClient;
 
-    public static class Config {}
+  public CustomAuthFilter(ObjectMapper objectMapper, WebClient.Builder webClientBuilder) {
+    super(Config.class);
+    this.objectMapper = objectMapper;
+    // Eureka에 등록된 User Server의 이름(대소문자 주의)으로 베이스 URL 세팅
+    this.webClient = webClientBuilder.baseUrl("http://user-server").build();
+  }
 
-    @Override
-    public GatewayFilter apply(Config config) {
-        return (exchange, chain) -> {
-            String path = exchange.getRequest().getURI().getPath();
+  public static class Config {}
 
-            if (EXCLUDE_PATHS.stream().anyMatch(path::startsWith)) {
-                return chain.filter(exchange);
-            }
+  @Override
+  public GatewayFilter apply(Config config) {
+    return (exchange, chain) -> {
+      String path = exchange.getRequest().getURI().getPath();
 
-            // 외부에서 들어온 X-Header 위조(Spoofing) 방지: 모든 X-Header 제거 후, 인증된 사용자 정보로 재설정
-            ServerHttpRequest secureRequest = exchange.getRequest().mutate()
-                    .headers(headers -> {
-                        headers.remove("X-User-Id");
-                        headers.remove("X-Role");
-                        headers.remove("X-Username");
-                        headers.remove("X-User-Name");
-                        headers.remove("X-User-Email");
-                    }).build();
-            
-            // 안전해진 요청으로 교체
-            var secureExchange = exchange.mutate().request(secureRequest).build();
+      if (EXCLUDE_PATHS.stream().anyMatch(path::startsWith)) {
+        return chain.filter(exchange);
+      }
 
-            // 토큰 존재 여부 확인
-            String authHeader = secureRequest.getHeaders().getFirst("Authorization");
-            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-                return unauthorizedResponse(secureExchange, "Token not found.");
-            }
+      // 외부에서 들어온 X-Header 위조(Spoofing) 방지: 모든 X-Header 제거 후, 인증된 사용자 정보로 재설정
+      ServerHttpRequest secureRequest =
+          exchange
+              .getRequest()
+              .mutate()
+              .headers(
+                  headers -> {
+                    headers.remove("X-User-Id");
+                    headers.remove("X-Role");
+                    headers.remove("X-Username");
+                    headers.remove("X-User-Name");
+                    headers.remove("X-User-Email");
+                  })
+              .build();
 
-            String token = authHeader.substring(7);
-            String userId;
+      // 안전해진 요청으로 교체
+      var secureExchange = exchange.mutate().request(secureRequest).build();
 
-            try {
-                // 토큰에서 UUID(sub)만 빠르게 추출
-                String[] parts = token.split("\\.");
-                String payload = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
-                JsonNode jsonNode = objectMapper.readTree(payload);
-                userId = jsonNode.path("sub").asText();
-                
-            } catch (Exception e) {
-                return unauthorizedResponse(secureExchange, "잘못된 토큰 형식입니다.");
-            }
+      // 토큰 존재 여부 확인
+      String authHeader = secureRequest.getHeaders().getFirst("Authorization");
+      if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+        return unauthorizedResponse(secureExchange, "Token not found.");
+      }
 
-            // WebClient로 User Server에 '진짜' 권한 상태 물어보기
-            return webClient.get()
-                    .uri("/internal/v1/users/" + userId) // 내부 단일 유저 조회 API
-                    .retrieve()
-                    .bodyToMono(UserResponse.class)
-                    .timeout(Duration.ofMillis(500)) // 0.5초 타임아웃 (장애 전파 방지)
-                    .switchIfEmpty(Mono.error(new RuntimeException("EMPTY_RESPONSE")))
-                    .flatMap(response -> {
-                        // 유저 정보가 없거나, 성공 응답이 아니거나, 정지(DELETED 등) 상태인 경우 차단
-                        if (response == null || !response.success() || response.data() == null) {
-                            return unauthorizedResponse(secureExchange, "Server authentication failed or user not found.");
-                        }
+      String token = authHeader.substring(7);
+      String userId;
 
-                        User user = response.data();
+      try {
+        // 토큰에서 UUID(sub)만 빠르게 추출
+        String[] parts = token.split("\\.");
+        String payload =
+            new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+        JsonNode jsonNode = objectMapper.readTree(payload);
+        userId = jsonNode.path("sub").asText();
 
-                        // 상태가 APPROVED가 아니라면 접근 차단 (비즈니스 요구사항에 맞게 수정)
-                        if (!"APPROVED".equals(user.status())) {
-                            return unauthorizedResponse(secureExchange, "Server authentication failed or user not found.");
-                        }
+      } catch (Exception e) {
+        return unauthorizedResponse(secureExchange, "잘못된 토큰 형식입니다.");
+      }
 
-                        try {
-                            String encodedName = URLEncoder.encode(user.name(), StandardCharsets.UTF_8.toString());
+      // WebClient로 User Server에 '진짜' 권한 상태 물어보기
+      return webClient
+          .get()
+          .uri("/internal/v1/users/" + userId) // 내부 단일 유저 조회 API
+          .retrieve()
+          .bodyToMono(UserResponse.class)
+          .timeout(Duration.ofMillis(500)) // 0.5초 타임아웃 (장애 전파 방지)
+          .switchIfEmpty(Mono.error(new RuntimeException("EMPTY_RESPONSE")))
+          .flatMap(
+              response -> {
+                // 유저 정보가 없거나, 성공 응답이 아니거나, 정지(DELETED 등) 상태인 경우 차단
+                if (response == null || !response.success() || response.data() == null) {
+                  return unauthorizedResponse(
+                      secureExchange, "Server authentication failed or user not found.");
+                }
 
-                            // 최종적으로 최신 정보 기반의 X-Header 세팅
-                            ServerHttpRequest authenticatedRequest = secureExchange.getRequest().mutate()
-                                    .header("X-User-Id", user.userId().toString())
-                                    .header("X-Role", user.role())
-                                    .header("X-Username", user.username())
-                                    .header("X-User-Name", encodedName)
-                                    .header("X-User-Email", user.email())
-                                    .headers(h -> h.remove("Authorization")) // 원본 토큰 삭제
-                                    .build();
+                User user = response.data();
 
-                            log.info("[CustomAuth Filter] Authenticated -> User: {}, Role: {}", user.username(), user.role());
-                            return chain.filter(secureExchange.mutate().request(authenticatedRequest).build());
+                // 상태가 APPROVED가 아니라면 접근 차단 (비즈니스 요구사항에 맞게 수정)
+                if (!"APPROVED".equals(user.status())) {
+                  return unauthorizedResponse(
+                      secureExchange, "Server authentication failed or user not found.");
+                }
 
-                        } catch (Exception e) {
-                            return unauthorizedResponse(secureExchange, "Header encoding error.");
-                        }
-                    })
-                    .onErrorResume(e -> {
-                        log.error("[CustomAuth Filter] User Server connection error (ID: {}): {}", userId, e.getMessage());
-                        return unauthorizedResponse(secureExchange, "Authentication server did not respond.");
-                    });
-        };
-    }
+                try {
+                  String encodedName =
+                      URLEncoder.encode(user.name(), StandardCharsets.UTF_8.toString());
 
-    // 401 에러 응답을 처리하는 유틸리티 메서드
-    private Mono<Void> unauthorizedResponse(org.springframework.web.server.ServerWebExchange exchange, String message) {
-        log.warn("[CustomAuth Filter] Authentication failed: {}", message);
-        exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
-        return exchange.getResponse().setComplete();
-    }
+                  // 최종적으로 최신 정보 기반의 X-Header 세팅
+                  ServerHttpRequest authenticatedRequest =
+                      secureExchange
+                          .getRequest()
+                          .mutate()
+                          .header("X-User-Id", user.userId().toString())
+                          .header("X-Role", user.role())
+                          .header("X-Username", user.username())
+                          .header("X-User-Name", encodedName)
+                          .header("X-User-Email", user.email())
+                          .headers(h -> h.remove("Authorization")) // 원본 토큰 삭제
+                          .build();
+
+                  log.info(
+                      "[CustomAuth Filter] Authenticated -> User: {}, Role: {}",
+                      user.username(),
+                      user.role());
+                  return chain.filter(
+                      secureExchange.mutate().request(authenticatedRequest).build());
+
+                } catch (Exception e) {
+                  return unauthorizedResponse(secureExchange, "Header encoding error.");
+                }
+              })
+          .onErrorResume(
+              e -> {
+                log.error(
+                    "[CustomAuth Filter] User Server connection error (ID: {}): {}",
+                    userId,
+                    e.getMessage());
+                return unauthorizedResponse(
+                    secureExchange, "Authentication server did not respond.");
+              });
+    };
+  }
+
+  // 401 에러 응답을 처리하는 유틸리티 메서드
+  private Mono<Void> unauthorizedResponse(
+      org.springframework.web.server.ServerWebExchange exchange, String message) {
+    log.warn("[CustomAuth Filter] Authentication failed: {}", message);
+    exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+    return exchange.getResponse().setComplete();
+  }
 }

--- a/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
+++ b/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
@@ -22,8 +22,10 @@ import reactor.core.publisher.Mono;
 @Component
 public class CustomAuthFilter extends AbstractGatewayFilterFactory<CustomAuthFilter.Config> {
 
-  private static final List<String> EXCLUDE_PATHS =
-      List.of("/api/v1/users/register", "/v1/users/register", "/register");
+  private static final List<String> PUBLIC_PREFIXES = List.of(
+      "/api/v1/auth/",
+      "/api/v1/public/"
+  );
 
   private final ObjectMapper objectMapper;
   private final WebClient webClient;
@@ -42,7 +44,7 @@ public class CustomAuthFilter extends AbstractGatewayFilterFactory<CustomAuthFil
     return (exchange, chain) -> {
       String path = exchange.getRequest().getURI().getPath();
 
-      if (EXCLUDE_PATHS.stream().anyMatch(path::startsWith)) {
+      if (PUBLIC_PREFIXES.stream().anyMatch(path::startsWith)) {
         return chain.filter(exchange);
       }
 

--- a/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
+++ b/src/main/java/com/followme/gatewayserver/filter/CustomAuthFilter.java
@@ -1,49 +1,140 @@
 package com.followme.gatewayserver.filter;
 
-import java.util.List;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.followme.gatewayserver.response.User;
+import com.followme.gatewayserver.response.UserResponse;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
 
 @Slf4j
 @Component
 public class CustomAuthFilter extends AbstractGatewayFilterFactory<CustomAuthFilter.Config> {
 
-  // 인증을 면제할 공개(Public) API 경로 목록 정의 (화이트리스트)
-  private static final List<String> EXCLUDE_PATHS = List.of("/api/v1/users/register");
+    private static final List<String> EXCLUDE_PATHS = List.of(
+      "/api/v1/users/register",
+      "/v1/users/register", 
+      "/register"
+    );
+    
+    private final ObjectMapper objectMapper;
+    private final WebClient webClient;
 
-  public CustomAuthFilter() {
-    super(Config.class);
-  }
+    public CustomAuthFilter(ObjectMapper objectMapper, WebClient.Builder webClientBuilder) {
+        super(Config.class);
+        this.objectMapper = objectMapper;
+        // Eureka에 등록된 User Server의 이름(대소문자 주의)으로 베이스 URL 세팅
+        this.webClient = webClientBuilder.baseUrl("http://user-server").build(); 
+    }
 
-  public static class Config {}
+    public static class Config {}
 
-  @Override
-  public GatewayFilter apply(Config config) {
-    return (exchange, chain) -> {
-      String path = exchange.getRequest().getURI().getPath();
-      log.info("[CustomAuth Filter] KeyCloak authentication filter started. Path: {}", path);
+    @Override
+    public GatewayFilter apply(Config config) {
+        return (exchange, chain) -> {
+            String path = exchange.getRequest().getURI().getPath();
 
-      boolean isExcluded = EXCLUDE_PATHS.stream().anyMatch(path::startsWith);
-      if (isExcluded) {
-        log.info(
-            "[CustomAuth Filter] Excluded path detected: {}. Proceeding without authentication.",
-            path);
-        return chain.filter(exchange);
-      }
+            if (EXCLUDE_PATHS.stream().anyMatch(path::startsWith)) {
+                return chain.filter(exchange);
+            }
 
-      String authorizationHeader = exchange.getRequest().getHeaders().getFirst("Authorization");
+            // 외부에서 들어온 X-Header 위조(Spoofing) 방지: 모든 X-Header 제거 후, 인증된 사용자 정보로 재설정
+            ServerHttpRequest secureRequest = exchange.getRequest().mutate()
+                    .headers(headers -> {
+                        headers.remove("X-User-Id");
+                        headers.remove("X-Role");
+                        headers.remove("X-Username");
+                        headers.remove("X-User-Name");
+                        headers.remove("X-User-Email");
+                    }).build();
+            
+            // 안전해진 요청으로 교체
+            var secureExchange = exchange.mutate().request(secureRequest).build();
 
-      if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-        log.warn("[CustomAuth Filter] Authentication failed: Invalid token for path {}", path);
+            // 토큰 존재 여부 확인
+            String authHeader = secureRequest.getHeaders().getFirst("Authorization");
+            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+                return unauthorizedResponse(secureExchange, "Token not found.");
+            }
+
+            String token = authHeader.substring(7);
+            String userId;
+
+            try {
+                // 토큰에서 UUID(sub)만 빠르게 추출
+                String[] parts = token.split("\\.");
+                String payload = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+                JsonNode jsonNode = objectMapper.readTree(payload);
+                userId = jsonNode.path("sub").asText();
+                
+            } catch (Exception e) {
+                return unauthorizedResponse(secureExchange, "잘못된 토큰 형식입니다.");
+            }
+
+            // WebClient로 User Server에 '진짜' 권한 상태 물어보기
+            return webClient.get()
+                    .uri("/internal/v1/users/" + userId) // 내부 단일 유저 조회 API
+                    .retrieve()
+                    .bodyToMono(UserResponse.class)
+                    .timeout(Duration.ofMillis(500)) // 0.5초 타임아웃 (장애 전파 방지)
+                    .switchIfEmpty(Mono.error(new RuntimeException("EMPTY_RESPONSE")))
+                    .flatMap(response -> {
+                        // 유저 정보가 없거나, 성공 응답이 아니거나, 정지(DELETED 등) 상태인 경우 차단
+                        if (response == null || !response.success() || response.data() == null) {
+                            return unauthorizedResponse(secureExchange, "Server authentication failed or user not found.");
+                        }
+
+                        User user = response.data();
+
+                        // 상태가 APPROVED가 아니라면 접근 차단 (비즈니스 요구사항에 맞게 수정)
+                        if (!"APPROVED".equals(user.status())) {
+                            return unauthorizedResponse(secureExchange, "Server authentication failed or user not found.");
+                        }
+
+                        try {
+                            String encodedName = URLEncoder.encode(user.name(), StandardCharsets.UTF_8.toString());
+
+                            // 최종적으로 최신 정보 기반의 X-Header 세팅
+                            ServerHttpRequest authenticatedRequest = secureExchange.getRequest().mutate()
+                                    .header("X-User-Id", user.userId().toString())
+                                    .header("X-Role", user.role())
+                                    .header("X-Username", user.username())
+                                    .header("X-User-Name", encodedName)
+                                    .header("X-User-Email", user.email())
+                                    .headers(h -> h.remove("Authorization")) // 원본 토큰 삭제
+                                    .build();
+
+                            log.info("[CustomAuth Filter] Authenticated -> User: {}, Role: {}", user.username(), user.role());
+                            return chain.filter(secureExchange.mutate().request(authenticatedRequest).build());
+
+                        } catch (Exception e) {
+                            return unauthorizedResponse(secureExchange, "Header encoding error.");
+                        }
+                    })
+                    .onErrorResume(e -> {
+                        log.error("[CustomAuth Filter] User Server connection error (ID: {}): {}", userId, e.getMessage());
+                        return unauthorizedResponse(secureExchange, "Authentication server did not respond.");
+                    });
+        };
+    }
+
+    // 401 에러 응답을 처리하는 유틸리티 메서드
+    private Mono<Void> unauthorizedResponse(org.springframework.web.server.ServerWebExchange exchange, String message) {
+        log.warn("[CustomAuth Filter] Authentication failed: {}", message);
         exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
         return exchange.getResponse().setComplete();
-      }
-
-      log.info("[CustomAuth Filter] Authentication successful, proceeding to next filter.");
-      return chain.filter(exchange);
-    };
-  }
+    }
 }

--- a/src/main/java/com/followme/gatewayserver/response/User.java
+++ b/src/main/java/com/followme/gatewayserver/response/User.java
@@ -3,10 +3,4 @@ package com.followme.gatewayserver.response;
 import java.util.UUID;
 
 public record User(
-        UUID userId,
-        String username,
-        String name,
-        String email,
-        String role,
-        String status
-) {}
+    UUID userId, String username, String name, String email, String role, String status) {}

--- a/src/main/java/com/followme/gatewayserver/response/User.java
+++ b/src/main/java/com/followme/gatewayserver/response/User.java
@@ -1,0 +1,12 @@
+package com.followme.gatewayserver.response;
+
+import java.util.UUID;
+
+public record User(
+        UUID userId,
+        String username,
+        String name,
+        String email,
+        String role,
+        String status
+) {}

--- a/src/main/java/com/followme/gatewayserver/response/UserResponse.java
+++ b/src/main/java/com/followme/gatewayserver/response/UserResponse.java
@@ -1,0 +1,7 @@
+package com.followme.gatewayserver.response;
+
+public record UserResponse(
+        boolean success,
+        User data,
+        String error
+) {}

--- a/src/main/java/com/followme/gatewayserver/response/UserResponse.java
+++ b/src/main/java/com/followme/gatewayserver/response/UserResponse.java
@@ -1,7 +1,3 @@
 package com.followme.gatewayserver.response;
 
-public record UserResponse(
-        boolean success,
-        User data,
-        String error
-) {}
+public record UserResponse(boolean success, User data, String error) {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,22 +4,45 @@ server:
 spring:
   application:
     name: gateway-server
+
+  # 시니어의 보안 검증 (Keycloak) - 필요시 주석 처리 후 진행 가능
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: "http://localhost:9090/realms/user/protocol/openid-connect/certs"
+          issuer-uri: "http://localhost:9090/realms/user"
+
   cloud:
     gateway:
-      server:
-        webflux:
-          # 전역 필터 설정
-          default-filters:
-            - AddRequestHeader=X-Gateway-Request, true
-          
-          # 개별 서비스 라우팅 전략
-          routes:
-            - id: user-server
-              uri: lb://USER-SERVER
-              predicates:
-                - Path=/api/v1/users/**
-              filters:
-                - name: CustomAuthFilter
+      globalcors:
+        cors-configurations:
+          '[/**]':
+            allowedOriginPatterns: "*"
+            allowedMethods: [GET, POST, PUT, DELETE, OPTIONS, PATCH]
+            allowedHeaders: "*"
+            allowCredentials: true
+            maxAge: 3600
+
+      discovery:
+        locator:
+          enabled: true
+          lower-case-service-id: true
+
+      routes:
+        - id: user-server
+          uri: lb://user-server
+          predicates:
+            - Path=/api/v1/users/**
+          filters:
+            - name: CustomAuthFilter
+
+        - id: hub-server
+          uri: lb://hub-server
+          predicates:
+            - Path=/api/v1/hubs/**
+          filters:
+            - name: CustomAuthFilter
 
 eureka:
   client:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,6 @@ spring:
   application:
     name: gateway-server
 
-  # 시니어의 보안 검증 (Keycloak) - 필요시 주석 처리 후 진행 가능
   security:
     oauth2:
       resourceserver:
@@ -40,7 +39,42 @@ spring:
         - id: hub-server
           uri: lb://hub-server
           predicates:
-            - Path=/api/v1/hubs/**
+            - Path=/api/v1/hubs/**, /api/v1/hub-routes/**, /api/v1/stocks/**, /api/v1/stock-histories/**
+          filters:
+            - name: CustomAuthFilter
+
+        - id: vendor-server
+          uri: lb://vendor-server
+          predicates:
+            - Path=/api/v1/vendors/**, /api/v1/products/**
+          filters:
+            - name: CustomAuthFilter
+
+        - id: order-server
+          uri: lb://order-server
+          predicates:
+            - Path=/api/v1/orders/**
+          filters:
+            - name: CustomAuthFilter
+
+        - id: delivery-server
+          uri: lb://delivery-server
+          predicates:
+            - Path=/api/v1/deliveries/**, /api/v1/shipments/**
+          filters:
+            - name: CustomAuthFilter
+
+        - id: message-server
+          uri: lb://message-server
+          predicates:
+            - Path=/api/v1/slack-messages/**, /api/v1/notifications/**
+          filters:
+            - name: CustomAuthFilter
+
+        - id: ai-server
+          uri: lb://ai-server
+          predicates:
+            - Path=/api/v1/ai/**
           filters:
             - name: CustomAuthFilter
 


### PR DESCRIPTION
📌 관련 이슈
- close #6

💡 작업 내용
- WebClient 기반 실시간 유저 상태 검증 필터 구현

- @LoadBalanced 설정 및 내부 통신용 DTO(record) 추가

- 외부 헤더 위조 방지를 위한 X-Header 초기화 및 재설정 로직 반영

🔍 변경 이유
- JWT의 데이터 정합성 한계를 극복하고 실시간 권한 통제를 수행하기 위함

- 게이트웨이 최전방 보안 강화를 통한 헤더 스푸핑 방지


🧠 기타 참고 사항
- User Server와의 /internal/v1/users/{id} 통신 규격 확인 완료

- Keycloak 로컬 환경 연동 테스트 완료