### PR TITLE
[FIX] API Gateway CORS 사전 요청(OPTIONS) 차단 문제 해결

### DIFF
--- a/src/main/java/com/followme/gatewayserver/config/GatewaySecurityConfig.java
+++ b/src/main/java/com/followme/gatewayserver/config/GatewaySecurityConfig.java
@@ -1,6 +1,7 @@
 package com.followme.gatewayserver.config;
 
 import java.util.Arrays;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -15,6 +16,9 @@ import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 @Configuration
 @EnableWebFluxSecurity
 public class GatewaySecurityConfig {
+
+  @Value("${cors.allowed-origins:http://localhost:8080}")
+  private String allowedOrigins;
 
   @Bean
   public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
@@ -49,7 +53,7 @@ public class GatewaySecurityConfig {
   public CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
 
-    configuration.setAllowedOrigins(Arrays.asList("http://localhost:8080"));
+    configuration.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
     configuration.setAllowedMethods(
         Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     configuration.setAllowedHeaders(Arrays.asList("*"));

--- a/src/main/java/com/followme/gatewayserver/config/GatewaySecurityConfig.java
+++ b/src/main/java/com/followme/gatewayserver/config/GatewaySecurityConfig.java
@@ -2,10 +2,16 @@ package com.followme.gatewayserver.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsConfigurationSource;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @Configuration
 @EnableWebFluxSecurity
@@ -13,21 +19,45 @@ public class GatewaySecurityConfig {
 
   @Bean
   public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
-    http.csrf(csrf -> csrf.disable())
+    http
+        // [추가 1] WebFlux Security에 CORS 설정 적용
+        .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+        
+        .csrf(csrf -> csrf.disable())
 
         // 1. 경로별 접근 통제
         .authorizeExchange(
             exchanges ->
                 exchanges
+                    // [추가 2] 브라우저의 CORS Preflight (OPTIONS) 요청은 토큰 없이 무조건 통과!
+                    .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                    
+                    // 기존에 설정하신 예외 경로들
                     .pathMatchers("/api/v1/auth/**", "/api/v1/public/**", "/api/v1/users/register")
                     .permitAll()
                     .anyExchange()
                     .authenticated() // 나머지는 무조건 인증(토큰) 필요
-            )
+        )
 
         // 2. application.yml에 적어둔 Keycloak 주소로 JWT 서명 검증 수행
         .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
 
     return http.build();
+  }
+
+  // [추가 3] 명시적인 CORS Configuration Bean 등록
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+      CorsConfiguration configuration = new CorsConfiguration();
+      
+      configuration.setAllowedOrigins(Arrays.asList("http://localhost:8080"));
+      configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+      configuration.setAllowedHeaders(Arrays.asList("*"));
+      configuration.setAllowCredentials(true);
+      configuration.setMaxAge(3600L);
+
+      UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+      source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 위 CORS 설정 적용
+      return source;
   }
 }

--- a/src/main/java/com/followme/gatewayserver/config/GatewaySecurityConfig.java
+++ b/src/main/java/com/followme/gatewayserver/config/GatewaySecurityConfig.java
@@ -1,5 +1,6 @@
 package com.followme.gatewayserver.config;
 
+import java.util.Arrays;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -11,8 +12,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.reactive.CorsConfigurationSource;
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
-
 @Configuration
 @EnableWebFluxSecurity
 public class GatewaySecurityConfig {
@@ -22,7 +21,6 @@ public class GatewaySecurityConfig {
     http
         // [추가 1] WebFlux Security에 CORS 설정 적용
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-        
         .csrf(csrf -> csrf.disable())
 
         // 1. 경로별 접근 통제
@@ -30,14 +28,15 @@ public class GatewaySecurityConfig {
             exchanges ->
                 exchanges
                     // [추가 2] 브라우저의 CORS Preflight (OPTIONS) 요청은 토큰 없이 무조건 통과!
-                    .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                    
+                    .pathMatchers(HttpMethod.OPTIONS, "/**")
+                    .permitAll()
+
                     // 기존에 설정하신 예외 경로들
                     .pathMatchers("/api/v1/auth/**", "/api/v1/public/**", "/api/v1/users/register")
                     .permitAll()
                     .anyExchange()
                     .authenticated() // 나머지는 무조건 인증(토큰) 필요
-        )
+            )
 
         // 2. application.yml에 적어둔 Keycloak 주소로 JWT 서명 검증 수행
         .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
@@ -48,16 +47,17 @@ public class GatewaySecurityConfig {
   // [추가 3] 명시적인 CORS Configuration Bean 등록
   @Bean
   public CorsConfigurationSource corsConfigurationSource() {
-      CorsConfiguration configuration = new CorsConfiguration();
-      
-      configuration.setAllowedOrigins(Arrays.asList("http://localhost:8080"));
-      configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-      configuration.setAllowedHeaders(Arrays.asList("*"));
-      configuration.setAllowCredentials(true);
-      configuration.setMaxAge(3600L);
+    CorsConfiguration configuration = new CorsConfiguration();
 
-      UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-      source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 위 CORS 설정 적용
-      return source;
+    configuration.setAllowedOrigins(Arrays.asList("http://localhost:8080"));
+    configuration.setAllowedMethods(
+        Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+    configuration.setAllowedHeaders(Arrays.asList("*"));
+    configuration.setAllowCredentials(true);
+    configuration.setMaxAge(3600L);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration); // 모든 경로에 대해 위 CORS 설정 적용
+    return source;
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,8 @@ spring:
         cors-configurations:
           '[/**]':
             allowedOriginPatterns: "*"
+            allowedOrigins: 
+              - "http://localhost:8080" # User Server Swagger 허용
             allowedMethods: [GET, POST, PUT, DELETE, OPTIONS, PATCH]
             allowedHeaders: "*"
             allowCredentials: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,8 +18,7 @@ spring:
         cors-configurations:
           '[/**]':
             allowedOriginPatterns: "*"
-            allowedOrigins: 
-              - "http://localhost:8080" # User Server Swagger 허용
+            allowedOrigins: "${CORS_ALLOWED_ORIGINS:http://localhost:8080}"
             allowedMethods: [GET, POST, PUT, DELETE, OPTIONS, PATCH]
             allowedHeaders: "*"
             allowCredentials: true


### PR DESCRIPTION
📌 관련 이슈
- close #10 

💡 작업 내용
- GatewaySecurityConfig 내 HttpMethod.OPTIONS 요청에 대해 permitAll() 적용

🔍 변경 이유
- User Server의 Swagger UI에서 Gateway로 API 테스트 시, Spring Security가 CORS 사전 요청(OPTIONS)을 401(Unauthorized)로 차단하여 본 요청이 도달하지 못하는 에러("Failed to fetch")를 해결하기 위함.

📝 리뷰 포인트 (선택)
- GatewaySecurityConfig의 보안 필터 체인에서 CORS 처리가 정상적으로 가장 먼저 수행되는지 확인 부탁드립니다.

🧠 기타 참고 사항
- WebFlux 기반의 Spring Cloud Gateway 특성상, application.yml의 globalcors 설정만으로는 Security 필터를 온전히 통과하지 못해 코드 단에서 명시적으로 처리했습니다.